### PR TITLE
modifies obj to have separate addition on ensemble and controls

### DIFF
--- a/esm4ppe/classes.py
+++ b/esm4ppe/classes.py
@@ -1,51 +1,61 @@
 """ Module for the esm4ppeObj class """
 import xarray as xr
 import climpred as cp
+import time
 from dask.diagnostics import ProgressBar
 
 from esm4ppe.version import sysconfig
 from esm4ppe.processing import *
+from esm4ppe.calculations import *
 
 class esm4ppeObj:
-    def __init__(self,variable,frequency,constraint=None,triggeropen=False,add_control=False):
-        zarrpath = sysconfig['zarrpathroot']+get_zarrdir(variable,frequency)
+    def __init__(self,variable,frequency,constraint=None):
+        
+        self.variable = variable
+        self.frequency = frequency
+        self.constraint = constraint
+        
+        print("Opening static...",end=" ")
+        self.static = open_static(variable,frequency,constraint)
+        print("static opened.")
+        
+    def add_ensemble(self,triggeropen=False,startyear='*',startmonth=None,controlasmember=True):
+        
+        zarrpath = sysconfig['zarrpathroot']+get_zarrdir(self.variable,self.frequency)
+        self.zarrpath = zarrpath
+        
         try:
-            ds = xr.open_zarr(zarrpath)[variable]
+            ensemble = xr.open_zarr(zarrpath)[self.variable]
             print("Opening zarr store.")
         except:
             if triggeropen:
                 print("Opening ensemble...",end=" ")
                 start = time.time()
-                ds = open_ensemble(variable,frequency,constraint,controlasmember=True)
+                ensemble = open_ensemble(self.variable,self.frequency,self.constraint,
+                                         controlasmember=controlasmember,
+                                         startyear=startyear,startmonth=startmonth)
                 end = time.time()
                 print("...Ensemble opened. Elapsed time: "+str(round(end-start))+" seconds.")
-                ds = ds.drop(['time_bnds','nv']).chunk({'member':-1,'init':-1,'lead':1,'xh':"auto"})
+                ensemble = ensemble.drop(['time_bnds','nv']).chunk({'member':-1,'init':-1,'lead':1,'xh':"auto"})
                 print("Saving to zarr store...",end=" ")
                 with ProgressBar():
-                    ds.to_zarr(zarrpath,mode='a')
+                    ensemble.to_zarr(zarrpath,mode='a')
                 print("zarr store saved.")
             else:
                 raise Exception("Zarr store not available for "+
-                                variable+" at zarrpath "+
-                                get_zarrpath(variable,frequency)+"."+
+                                self.variable+" at zarrpath "+
+                                get_zarrpath(self.variable,self.frequency)+"."+
                                 "Set triggeropen=True to open and save the ensemble."+
                                 " This can take some time to process.")
         
-        if type(ds)==xr.DataArray:
-            ds = ds.to_dataset()
-        self._ds = ds
+        if type(ensemble)==xr.DataArray:
+            ensemble = ensemble.to_dataset()
+        self.ensemble = ensemble
         
-        self.args = {'variable':variable,'frequency':frequency,'constraint':constraint}
-        self.zarrpath = zarrpath
-        
-        if add_control:
-            print("Opening control...",end=" ")
-            self._control = open_control(variable,frequency,constraint)
-            print("control opened.")
-        
-        print("Opening static...",end=" ")
-        self._static = open_static(variable,frequency,constraint)
-        print("static opened.")
+    def add_control(self):
+        print("Opening control...",end=" ")
+        self.control = open_control(self.variable,self.frequency,self.constraint)
+        print("control opened.")
         
         
     def verify(self,metric,saveskill=False,**pm_args):


### PR DESCRIPTION
This simple pull request changes the initialization of the `esm4ppeObj` to no longer open the ensemble and control data automatically. Now, they are performed by the user call to `.add_ensemble` or `add_control`. There are also a couple of other random modifications.